### PR TITLE
Add docker build and publish to ghcr.io

### DIFF
--- a/.github/workflows/indexer.yml
+++ b/.github/workflows/indexer.yml
@@ -28,3 +28,42 @@ jobs:
       - name: Build
         run: tsc
         working-directory: ./indexer
+
+  docker-publish:
+    name: Build and Publish Docker Image to GHCR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract branch and sha for tags
+        id: vars
+        run: |
+          BRANCH=$(echo "${GITHUB_REF#refs/heads/}" | sed 's/\//-/g')
+          SHA=$(echo $GITHUB_SHA | cut -c1-7)
+          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
+          echo "SHA=$SHA" >> $GITHUB_ENV
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.development
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/indexer-kadena:${{ env.BRANCH }}
+            ghcr.io/${{ github.repository_owner }}/indexer-kadena:sha-${{ env.SHA }}


### PR DESCRIPTION
This is a proposed update to the CI to publish a container to your ghcr.io repo.  You will likely have to go edit the permissions of the container in github after it creates it the first time, to allow this repository write access to the container.  You can modify this however you wish; I am using the format commonly used at Kadena where we call the tags 'sha-xxxxxxx' and 'branchname'.  A 'release' workflow or release override version of this workflow could be used to manually run this CI and append the tag 'latest' to the last released version.

This is helpful for us because we have workflows that reference this indexer repo and build the container for doing various integration tests.  We just pull of the main branch here and thus may be subject to unstable changes.  As things are under development it could be fine to just point to :main on our side for now, but eventually having a stable :latest would be good for consistency.

Other notes: there is a Dockerfile.development and a Dockerfile in the main repo here; we have been using the .development one because that is the one that worked correctly a while ago when we started this.  I am unsure of the practical differences, but I imagine it could all be done in the main Dockerfile.

For an example of our use of this repo in a docker compose setup for local testing, see this file: https://github.com/kadena-io/devnet/blob/main/docker-compose.indexer.yaml