### PR TITLE
fix: liquidity can be object or number

### DIFF
--- a/indexer/src/services/pair-service.ts
+++ b/indexer/src/services/pair-service.ts
@@ -778,7 +778,15 @@ export class PairService {
             // Parse the parameters
             const [sender, to, token0Ref, token1Ref, amount0, amount1, liquidity] = JSON.parse(
               event.parameters,
-            ) as [string, string, TokenReference, TokenReference, TokenAmount, TokenAmount, number];
+            ) as [
+              string,
+              string,
+              TokenReference,
+              TokenReference,
+              TokenAmount,
+              TokenAmount,
+              TokenAmount,
+            ];
 
             // Convert TokenAmount to string representation
             const amount0Str = typeof amount0 === 'number' ? amount0.toString() : amount0.decimal;
@@ -820,10 +828,12 @@ export class PairService {
             );
 
             let totalSupply = Number(pair.totalSupply);
+            const liquidityStr =
+              typeof liquidity === 'number' ? liquidity.toString() : liquidity.decimal;
             if (event.name === 'ADD_LIQUIDITY') {
-              totalSupply = Number(pair.totalSupply) + Number(liquidity);
+              totalSupply = Number(pair.totalSupply) + Number(liquidityStr);
             } else {
-              totalSupply = Number(pair.totalSupply) - Number(liquidity);
+              totalSupply = Number(pair.totalSupply) - Number(liquidityStr);
             }
             await pair.update(
               {


### PR DESCRIPTION
This PR is to fix the oversight that `liquidity` value returned from an add or remove liquidity event could be a number or an object with key `decimal`.